### PR TITLE
Convert scanned amount to correct unit

### DIFF
--- a/app/src/controllers/wallet/send/wallet_send_index_dialog_view_controller.coffee
+++ b/app/src/controllers/wallet/send/wallet_send_index_dialog_view_controller.coffee
@@ -50,7 +50,8 @@ class @WalletSendIndexDialogViewController extends ledger.common.DialogViewContr
         params = {address: data}
       else
         params = ledger.managers.schemes.bitcoin.parseURI data
-      @view.amountInput.val params.amount if params?.amount?
+      if params?.amount?
+        @view.amountInput.val(ledger.formatters.formatUnit(ledger.formatters.fromBtcToSatoshi(params.amount), ledger.preferences.instance.getBtcUnit()))
       @view.receiverInput.val params.address if params?.address?
       @_updateTotalInput()
     dialog.show()


### PR DESCRIPTION
If the user sets the display unit to anything other than BTC and scans a payment request QR code, the scanned amount (which is always given in BTC) needs to be converted to the user's selected unit.