### PR TITLE
Fix formatting of amount in bitcoin: uri

### DIFF
--- a/app/src/controllers/wallet/receive/wallet_receive_index_dialog_view_controller.coffee
+++ b/app/src/controllers/wallet/receive/wallet_receive_index_dialog_view_controller.coffee
@@ -34,7 +34,7 @@ class @WalletReceiveIndexDialogViewController extends ledger.common.DialogViewCo
   _listenEvents: ->
     @view.amountInput.on 'keydown', (e) =>
       _.defer =>
-        @params.amount = ledger.formatters.fromSatoshiToBTC(ledger.formatters.fromValueToSatoshi(@view.amountInput.val()))
+        @params.amount = ledger.formatters.fromSatoshiToBIP0021(ledger.formatters.fromValueToSatoshi(@view.amountInput.val()))
         @_refreshQrCode()
 
   _refreshQrCode: () ->

--- a/app/src/utils/formatters.coffee
+++ b/app/src/utils/formatters.coffee
@@ -112,6 +112,25 @@ class ledger.formatters
 
 
   ###
+    This method converts Satoshi to BTC according to BIP0021
+
+    @param [Number] value An input value in satoshi
+    @return [String] The formatted value
+  ###
+  @fromSatoshiToBIP0021: (value) ->
+    satoshis = new Bitcoin.BigInteger(value.toString())
+    result = satoshis.divideAndRemainder(new Bitcoin.BigInteger('100000000'))
+    value = result[0].toString()
+    fractionalPart = result[1]
+
+    if fractionalPart.compareTo(Bitcoin.BigInteger.ZERO)
+      fractionalPart = _.str.lpad(fractionalPart.toString(), 8, '0')
+      fractionalPart = fractionalPart.replace(/\.?0+$/, '')
+      value += '.' + fractionalPart.toString()
+    value
+
+
+  ###
     This method converts Satoshi to mBTC
 
     @param [Number] value An input value in Satoshi


### PR DESCRIPTION
Quoting from BIP 0021:
"All amounts MUST contain no commas and use a period (.) as the
separating character to separate whole numbers and decimal fractions."