### PR TITLE
Sign message with key path via API

### DIFF
--- a/app/assets/css/wallet/xpubkey/processing.less
+++ b/app/assets/css/wallet/xpubkey/processing.less
@@ -1,7 +1,7 @@
 @import (reference) "../../constants";
 @import (reference) "../../common";
 
-section#wallet_xpubkey_processing_dialog {
+section#wallet_xpubkey_processing_dialog, section#wallet_message_processing_dialog {
   width: @dialog-width-send;
 
   > #content_container {

--- a/app/locales/en/messages.properties
+++ b/app/locales/en/messages.properties
@@ -552,6 +552,19 @@ wallet.xpubkey.processing.info = Computing extended public key
 wallet.xpubkey.errors.cancelled = Export request cancelled
 wallet.xpubkey.errors.derivation_failed = Failed to compute the xpubkey
 wallet.xpubkey.errors.derivation_successfull = Export successful
+# Wallet Message Index
+wallet.message.index.title =  Wallet Message
+wallet.message.index.info = Sign message with the key corresponding to the following path\:
+wallet.message.index.path = Derivation path
+wallet.message.index.message = Message to sign
+# Wallet Message Processing
+wallet.message.processing.title = Wallet Message
+wallet.message.processing.info = Signing message
+# Wallet Message Errors
+wallet.message.errors.cancelled = Message signing request cancelled
+wallet.message.errors.derivation_failed = Failed to compute signing key
+wallet.message.errors.sign_message_failed = Failed to sign message
+wallet.message.errors.sign_message_successfull = Successfully signed message
 # Wallet P2SH Index
 wallet.p2sh.index.title = Signature request
 wallet.p2sh.index.info = Do you want to proceed with the signature?

--- a/app/src/api.coffee
+++ b/app/src/api.coffee
@@ -78,22 +78,7 @@ class @Api
       return
 
   @signMessage: (data) ->
-    try
-      ledger.bitcoin.bitid.getAddress path: data.path
-      .then (result) =>
-        @address = result.bitcoinAddress.value
-        ledger.bitcoin.bitid.signMessage(data.message, path: data.path)
-        .then (result) =>
-          @callback_success('sign_message', signature: result, address: @address)
-          return
-        .fail (error) =>
-          @callback_cancel('sign_message', JSON.stringify(error))
-          return
-      .fail (error) =>
-        @callback_cancel('sign_message', JSON.stringify(error))
-        return
-    catch error
-      callback_cancel('sign_message', JSON.stringify(error))
+    ledger.app.router.go '/wallet/message/index', {path: data.path, message: data.message}
 
   @cosignTransaction: (data) ->
     try

--- a/app/src/background.coffee
+++ b/app/src/background.coffee
@@ -132,6 +132,12 @@ chrome.runtime.onMessageExternal.addListener (request, sender, sendResponse) =>
         command: 'get_xpubkey',
         path: data.path
       }
+    when 'sign_message'
+      payload = {
+        command: 'sign_message',
+        path: data.path,
+        message: data.message
+      }
     when 'sign_p2sh'
       payload = {
         command: 'sign_p2sh',

--- a/app/src/controllers/wallet/message/wallet_message_index_dialog_view_controller.coffee
+++ b/app/src/controllers/wallet/message/wallet_message_index_dialog_view_controller.coffee
@@ -1,0 +1,23 @@
+class @WalletMessageIndexDialogViewController extends ledger.common.DialogViewController
+
+  view:
+    derivationPath: '#derivation_path'
+    message: '#message'
+    confirmButton: '#confirm_button'
+
+  onAfterRender: ->
+    super
+    chrome.app.window.current().show()
+    @path = Api.cleanPath(@params.path)
+    @message = @params.message
+    @view.derivationPath.text("m/" + @path)
+    @view.message.text(@message)
+
+  cancel: ->
+    Api.callback_cancel 'sign_message', t('wallet.message.errors.cancelled')
+    @dismiss()
+
+  confirm: ->
+    dialog = new WalletMessageProcessingDialogViewController(path: @path, message: @message)
+    @getDialog().push dialog
+

--- a/app/src/controllers/wallet/message/wallet_message_processing_dialog_view_controller.coffee
+++ b/app/src/controllers/wallet/message/wallet_message_processing_dialog_view_controller.coffee
@@ -1,0 +1,38 @@
+class @WalletMessageProcessingDialogViewController extends ledger.common.DialogViewController
+
+  view:
+    contentContainer: '#content_container'
+    
+  onAfterRender: ->
+    super
+    @view.spinner = ledger.spinners.createLargeSpinner(@view.contentContainer[0])
+    try
+      ledger.bitcoin.bitid.getAddress path: @params.path
+      .then (result) =>
+        address = result.bitcoinAddress.value
+        ledger.bitcoin.bitid.signMessage(@params.message, path: @params.path)
+        .then (result) =>
+          Api.callback_success('sign_message', signature: result, address: address)
+          @dismiss =>
+            dialog = new CommonDialogsMessageDialogViewController(kind: "success", title: t("wallet.message.errors.sign_message_successfull"))
+            dialog.show()
+          return
+        .fail (error) =>
+          Api.callback_cancel('sign_message', JSON.stringify(error))
+          @dismiss =>
+            dialog = new CommonDialogsMessageDialogViewController(kind: "error", title: t("wallet.message.errors.sign_message_failed"), subtitle: error)
+            dialog.show()
+          return
+      .fail (error) =>
+        Api.callback_cancel('sign_message', JSON.stringify(error))
+        @dismiss =>
+          dialog = new CommonDialogsMessageDialogViewController(kind: "error", title: t("wallet.message.errors.derivation_failed"), subtitle: error)
+          dialog.show()
+        return
+    catch error
+      Api.callback_cancel('sign_message', JSON.stringify(error))
+      @dismiss =>
+        dialog = new CommonDialogsMessageDialogViewController(kind: "error", title: t("wallet.message.errors.sign_message_failed"), subtitle: error)
+        dialog.show()
+
+

--- a/app/src/imports.coffee
+++ b/app/src/imports.coffee
@@ -296,6 +296,10 @@
         'controllers/wallet/xpubkey/wallet_xpubkey_index_dialog_view_controller'
         'controllers/wallet/xpubkey/wallet_xpubkey_processing_dialog_view_controller'
 
+        # Message
+        'controllers/wallet/message/wallet_message_index_dialog_view_controller'
+        'controllers/wallet/message/wallet_message_processing_dialog_view_controller'
+
         # P2SH
         'controllers/wallet/p2sh/wallet_p2sh_index_dialog_view_controller'
         'controllers/wallet/p2sh/wallet_p2sh_signing_dialog_view_controller'

--- a/app/src/routes.coffee
+++ b/app/src/routes.coffee
@@ -199,6 +199,11 @@ ledger.router.pluggedWalletRoutesExceptions = [
     dialog = new WalletXpubkeyIndexDialogViewController({ path: params["?params"]?.path })
     dialog.show()
 
+  # Message
+  route '/wallet/message/index', (params = {}) ->
+    dialog = new WalletMessageIndexDialogViewController({ path: params["?params"]?.path, message: params["?params"]?.message })
+    dialog.show()
+
   # P2SH
   route '/wallet/p2sh/index', (params = {}) ->
     dialog = new WalletP2shIndexDialogViewController({ inputs: params["?params"]?.inputs, scripts: params["?params"]?.scripts, outputs_number: params["?params"]?.outputs_number, outputs_script: params["?params"]?.outputs_script, paths: params["?params"]?.paths })

--- a/app/views/wallet/message/index.eco
+++ b/app/views/wallet/message/index.eco
@@ -1,20 +1,28 @@
-<section id="wallet_xpubkey_index_dialog">
+<section id="wallet_message_index_dialog">
   <header>
-    <h1><%= t 'wallet.xpubkey.index.title' %></h1>
+    <h1><%= t 'wallet.message.index.title' %></h1>
   </header>
   <table class="no-table-head">
     <tbody>
       <tr>
         <td class="no-border">
-          <%= t 'wallet.xpubkey.index.info' %>
+          <%= t 'wallet.message.index.info' %>
         </td>
       </tr>
       <tr>
-        <td class="row-title"><%= t 'wallet.xpubkey.index.path' %></td>
+        <td class="row-title"><%= t 'wallet.message.index.path' %></td>
       </tr>
       <tr>
         <td>
           <span id="derivation_path"></span>
+        </td>
+      </tr>
+      <tr>
+        <td class="row-title"><%= t 'wallet.message.index.message' %></td>
+      </tr>
+      <tr>
+        <td>
+          <span id="message"></span>
         </td>
       </tr>
     </tbody>
@@ -26,3 +34,4 @@
   <a class="cancel-rounded-button" href="#cancel"><%= t 'common.cancel' %></a>
   <a class="action-rounded-button" href="#confirm"><%= t 'common.confirm' %></a>
 </div>
+

--- a/app/views/wallet/message/processing.eco
+++ b/app/views/wallet/message/processing.eco
@@ -1,0 +1,13 @@
+<section id="wallet_message_processing_dialog">
+  <header>
+    <h1><%= t 'wallet.message.processing.title' %></h1>
+  </header>
+  <div id="content_container">
+    <div class="regular-text"><%= t 'wallet.message.processing.info' %></div>
+    <div class="regular-grey-text-small"><%= t 'common.may_take_a_while' %></div>
+  </div>
+</section>
+<div class="dialog-actions-bar">
+  <div class="left-spacer"></div>
+  <a class="cancel-rounded-button" href="#dismiss"><%= t 'common.cancel' %></a>
+</div>

--- a/app/views/wallet/xpubkey/index.eco
+++ b/app/views/wallet/xpubkey/index.eco
@@ -8,7 +8,7 @@
         <td class="no-border">
           <%= t 'wallet.xpubkey.index.info' %>
         </td>
-      </tr>
+      </tr>    
       <tr>
         <td class="row-title"><%= t 'wallet.xpubkey.index.path' %></td>
       </tr>


### PR DESCRIPTION
This PR exposes the `sign_message` API and includes a set of confirmation dialogs modeled after the `get_xpubkey` dialogs. 

I also have a PR ready for `ledger-wallet-api` that supports this added functionality. 

```javascript
Ledger.signMessage("m/1/2/3", "this is a test message")
```

Here are a couple screenshots of the dialogs:

<img width="420" alt="wallet-message-index" src="https://cloud.githubusercontent.com/assets/16561/21033581/67d4c286-bd7f-11e6-9904-bf7b524adac4.png">

<img width="443" alt="wallet-message-processing" src="https://cloud.githubusercontent.com/assets/16561/21033582/6bc7df40-bd7f-11e6-84a9-c9b026239121.png">

<img width="277" alt="wallet-message-success" src="https://cloud.githubusercontent.com/assets/16561/21033585/6f8dd5ee-bd7f-11e6-83a7-fed15436ec8b.png">



