### PR TITLE
Support language-specific plural forms of coins

### DIFF
--- a/app/locales/en/messages.properties
+++ b/app/locales/en/messages.properties
@@ -13,6 +13,12 @@ application.commands.export_logs = Export the global logs
 application.singleton.alert_message = The {APPLICATION_NAME} application is already running. Please close it first and try again.
 
 # Common
+common.bitcoin_plural = bitcoins
+common.litecoin_plural = litecoins
+common.dogecoin_plural = dogecoins
+common.dash_plural = dash
+common.zcash_plural = zcash
+common.clubcoin_plural = clubcoins
 common.default_account_name = My account
 common.default_recovered_account_name = Recovered account %d
 common.date_time_format = L [at] LT

--- a/app/src/bitcoin/networks.coffee
+++ b/app/src/bitcoin/networks.coffee
@@ -28,7 +28,7 @@ ledger.bitcoin.Networks =
   bitcoin:
     name: 'bitcoin'
     bolosAppName: 'Bitcoin'
-    plural: 'bitcoins'
+    plural: -> t('common.bitcoin_plural')
     ticker: 'btc'
     scheme: 'bitcoin:'
     tickerKey:
@@ -46,7 +46,7 @@ ledger.bitcoin.Networks =
 
   testnet:
     name: 'testnet'
-    plural: 'bitcoins'
+    plural: -> t('common.bitcoin_plural')
     ticker: 'btctest'
     scheme: 'bitcoin:'
     bip44_coin_type: '1'
@@ -60,7 +60,7 @@ ledger.bitcoin.Networks =
 
   segnet:
     name: 'segnet'
-    plural: 'bitcoins'
+    plural: -> t('common.bitcoin_plural')
     ticker: 'segtest'
     scheme: 'bitcoin:'
     bip44_coin_type: '1'
@@ -83,7 +83,7 @@ ledger.bitcoin.Networks =
 
   litecoin:
     name: 'litecoin'
-    plural: 'litecoins'
+    plural: -> t('common.litecoin_plural')
     scheme: 'litecoin:'
     bolosAppName: 'Litecoin'
     ticker: 'ltc'
@@ -101,7 +101,7 @@ ledger.bitcoin.Networks =
 
   dogecoin:
     name: 'dogecoin'
-    plural: 'dogecoins'
+    plural: -> t('common.dogecoin_plural')
     scheme: 'dogecoin:'
     bolosAppName: 'Dogecoin'
     ticker: 'doge'
@@ -119,7 +119,7 @@ ledger.bitcoin.Networks =
 
   dash:
     name: 'dash'
-    plural: 'dash'
+    plural: -> t('common.dash_plural')
     scheme: 'dash:'
     bolosAppName: 'Dash'
     ticker: 'dash'
@@ -137,7 +137,7 @@ ledger.bitcoin.Networks =
 
   zcash:
     name: 'zcash'
-    plural: 'zcash'
+    plural: -> t('common.zcash_plural')
     scheme: 'zcash:'
     bolosAppName: 'Zcash'
     ticker: 'zec'
@@ -155,7 +155,7 @@ ledger.bitcoin.Networks =
 
   clubcoin:
     name: 'clubcoin'
-    plural: 'clubcoins'
+    plural: -> t('common.clubcoin_plural')
     scheme: 'clubcoin:'
     bolosAppName: 'ClubCoin'
     ticker: 'club'

--- a/app/src/controllers/apps/coinkite/dashboard/apps_coinkite_dashboard_compatibility_view_controller.coffee
+++ b/app/src/controllers/apps/coinkite/dashboard/apps_coinkite_dashboard_compatibility_view_controller.coffee
@@ -14,5 +14,5 @@ class @AppsCoinkiteDashboardCompatibilityDialogViewController extends ledger.com
           dialog.show()
       else
         @dismiss =>
-          dialog = new CommonDialogsMessageDialogViewController(kind: "error", title: t("apps.coinkite.dashboard.compatibility.fail"), subtitle: _.str.sprintf(t("apps.coinkite.dashboard.compatibility.fail_text"), ledger.config.network.plural))
+          dialog = new CommonDialogsMessageDialogViewController(kind: "error", title: t("apps.coinkite.dashboard.compatibility.fail"), subtitle: _.str.sprintf(t("apps.coinkite.dashboard.compatibility.fail_text"), ledger.config.network.plural()))
           dialog.show()

--- a/app/src/routes.coffee
+++ b/app/src/routes.coffee
@@ -49,17 +49,17 @@ ledger.router.pluggedWalletRoutesExceptions = [
   route '/onboarding/device/wrongpin', (params) ->
     app.router.go '/onboarding/device/error',
       message: _.str.sprintf t('onboarding.device.errors.wrongpin.tries_left'), params['?params'].tries_left
-      indication: _.str.sprintf(t('onboarding.device.errors.wrongpin.unplug_plug'), ledger.config.network.plural)
+      indication: _.str.sprintf(t('onboarding.device.errors.wrongpin.unplug_plug'), ledger.config.network.plural())
 
   route '/onboarding/device/frozen', (params) ->
     app.router.go '/onboarding/device/error',
       serious: yes
-      message: _.str.sprintf(t('onboarding.device.errors.frozen.blank_next_time'), ledger.config.network.plural)
-      indication: _.str.sprintf(t('onboarding.device.errors.frozen.unplug_plug'), ledger.config.network.plural)
+      message: _.str.sprintf(t('onboarding.device.errors.frozen.blank_next_time'), ledger.config.network.plural())
+      indication: _.str.sprintf(t('onboarding.device.errors.frozen.unplug_plug'), ledger.config.network.plural())
 
   route '/onboarding/device/forged', (params) ->
     app.router.go '/onboarding/device/error',
-      message: _.str.sprintf(t('onboarding.device.errors.forged.forbidden_access'), ledger.config.network.plural)
+      message: _.str.sprintf(t('onboarding.device.errors.forged.forbidden_access'), ledger.config.network.plural())
       indication: t 'onboarding.device.errors.forged.get_help'
 
   route '/onboarding/device/swapped_bip39_provisioning', (params) ->

--- a/app/views/onboarding/management/done.eco
+++ b/app/views/onboarding/management/done.eco
@@ -6,7 +6,7 @@
     <img src="../../assets/images/common/large_<%= if @params.error? then 'error' else 'check' %>.png" width="50" height="50" />
     <div class="black-indication"><%= if @params.error? then t 'onboarding.management.done.configuration_failed_' + @params.wallet_mode else t 'onboarding.management.done.configuration_is_complete_' + @params.wallet_mode %></div>
     <% if not @params.error?: %>
-    <div class="medium-indication"><%= _.str.sprintf(t('onboarding.management.done.unplug_plug'), ledger.config.network.plural) %></div>
+    <div class="medium-indication"><%= _.str.sprintf(t('onboarding.management.done.unplug_plug'), ledger.config.network.plural()) %></div>
     <% else: %>
     <a href="#openSupport" class="action-rounded-button"><%= t 'onboarding.management.done.contact_support' %></a>
     <% end %>

--- a/app/views/onboarding/management/recoverydevice.eco
+++ b/app/views/onboarding/management/recoverydevice.eco
@@ -3,7 +3,7 @@
     <div class="titles">
       <div class="page-title"><%= t 'onboarding.management.recover_my_wallet' %></div>
       <div class="page-subtitle"><%= t 'application.name' %></div>
-      <div class="page-strong-indication"><%= _.str.sprintf(t('onboarding.management.recoverydevice.recovering_on_new_wallet'), ledger.config.network.plural) %></div>
+      <div class="page-strong-indication"><%= _.str.sprintf(t('onboarding.management.recoverydevice.recovering_on_new_wallet'), ledger.config.network.plural()) %></div>
       <div class="page-indication"><%= t 'onboarding.management.recoverydevice.may_need_to_convert' %></div>
     </div>
   </div>
@@ -11,7 +11,7 @@
     <a class="panel" href="#navigatePin">
       <img src="../../assets/images/onboarding/management/existing_ledger_wallet.png" width="92" height="21"/>
       <div class="title"><%= t 'onboarding.management.recoverydevice.no_its_the_same' %></div>
-      <div class="subtitle"><%= _.str.sprintf(t('onboarding.management.recoverydevice.i_froze_my_device'), ledger.config.network.plural) %></div>
+      <div class="subtitle"><%= _.str.sprintf(t('onboarding.management.recoverydevice.i_froze_my_device'), ledger.config.network.plural()) %></div>
     </a>
     <a class="panel" href="#navigateConvert">
       <img src="../../assets/images/onboarding/management/new_ledger_wallet.png" width="112" height="32"/>

--- a/app/views/onboarding/management/seed.eco
+++ b/app/views/onboarding/management/seed.eco
@@ -22,7 +22,7 @@
   <div class="page-content-container">
     <div id="seed_container"></div>
     <div id="invalid_label"><span class="invalid-indication"><%= t 'onboarding.management.seed.invalid_recovery_phrase' %></span></div>
-    <div id="indication_label"><span class="black-indication-strong"><%= t 'onboarding.management.seed.it_wont_be_displayed_again' %></span> <span class="black-indication"><%= _.str.sprintf(t('onboarding.management.seed.without_it'), ledger.config.network.plural) %></span></div>
+    <div id="indication_label"><span class="black-indication-strong"><%= t 'onboarding.management.seed.it_wont_be_displayed_again' %></span> <span class="black-indication"><%= _.str.sprintf(t('onboarding.management.seed.without_it'), ledger.config.network.plural()) %></span></div>
   </div>
   <div class="navigation-container">
     <a class="back" href="#navigateRoot" id="back_button"><i class="fa fa-angle-left"></i> <%= t 'onboarding.management.cancel' %></a>

--- a/app/views/onboarding/management/summary.eco
+++ b/app/views/onboarding/management/summary.eco
@@ -12,7 +12,7 @@
     <div class="texts">
       <span class="black-title"><%= t 'onboarding.management.summary.your_wallet_is' %></span>
       <span class="black-strong-title"><%= t 'onboarding.management.summary.almost_ready' %></span>
-      <div class="black-indication"><%= _.str.sprintf((if @params.wallet_mode == 'create' then t 'onboarding.management.summary.use_your_bitcoins_create' else t 'onboarding.management.summary.use_your_bitcoins_other'), ledger.config.network.plural)%></div>
+      <div class="black-indication"><%= _.str.sprintf((if @params.wallet_mode == 'create' then t 'onboarding.management.summary.use_your_bitcoins_create' else t 'onboarding.management.summary.use_your_bitcoins_other'), ledger.config.network.plural())%></div>
     </div>
   </div>
   <div class="page-content-container">

--- a/app/views/onboarding/management/welcome.eco
+++ b/app/views/onboarding/management/welcome.eco
@@ -19,7 +19,7 @@
     <img class="index" src="../../assets/images/onboarding/management/restore_icon.png" width="40" height="40"/>
     <div class="texts">
       <div class="black-title"><%= t 'onboarding.management.welcome.recover_wallet' %></div>
-      <div class="black-indication"><%= _.str.sprintf(t('onboarding.management.welcome.if_you_lost_your_wallet'), ledger.config.network.plural) %></div>
+      <div class="black-indication"><%= _.str.sprintf(t('onboarding.management.welcome.if_you_lost_your_wallet'), ledger.config.network.plural()) %></div>
     </div>
     <img class="arrow" src="../assets/images/onboarding/large_right_arrow.png" width="16" height="30"/>
   </a>

--- a/app/views/update/done.eco
+++ b/app/views/update/done.eco
@@ -1,5 +1,5 @@
 <div id="view_controller_content">
   <img src="../assets/images/common/large_check.png" width="50" height="50" />
   <div class="page-large-indication"><%- t 'update.done.successfully_updated' %></div>
-  <div class="page-indication"><%- _.str.sprintf(t(if @params.provisioned then 'update.done.enjoy' else 'update.done.use_24_words'), ledger.config.network.plural)%></div>
+  <div class="page-indication"><%- _.str.sprintf(t(if @params.provisioned then 'update.done.enjoy' else 'update.done.use_24_words'), ledger.config.network.plural())%></div>
 </div>

--- a/app/views/update/erasing.eco
+++ b/app/views/update/erasing.eco
@@ -1,6 +1,6 @@
 <div id="view_controller_content">
   <img src="../assets/images/update/flash.png" width="50" height="50" />
   <div class="page-large-indication"><%- t 'update.erasing.ready_to_start_process' %></div>
-  <div class="page-indication"><%- _.str.sprintf(t('update.erasing.clicking_continue'), ledger.config.network.plural) %></div>
+  <div class="page-indication"><%- _.str.sprintf(t('update.erasing.clicking_continue'), ledger.config.network.plural()) %></div>
   <div class="regular-grey-text-small"><%= t 'update.erasing.please_note' %></div>
 </div>

--- a/app/views/update/index.eco
+++ b/app/views/update/index.eco
@@ -1,5 +1,5 @@
 <div id="view_controller_content">
-  <div class="page-large-indication"><%- _.str.sprintf(t('update.index.update_process'), ledger.config.network.plural) %></div>
+  <div class="page-large-indication"><%- _.str.sprintf(t('update.index.update_process'), ledger.config.network.plural()) %></div>
   <div class="page-indication"><%- t 'update.index.clicking_continue' %></div>
   <div class="regular-grey-text-small"><%= t 'update.index.please_note' %></div>
 </div>

--- a/app/views/wallet/receive/index.eco
+++ b/app/views/wallet/receive/index.eco
@@ -1,6 +1,6 @@
 <section id="receive_index_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.receive.index.title'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.receive.index.title'), ledger.config.network.plural()) %></h1>
   </header>
   <table class="no-table-head">
     <tbody>
@@ -33,7 +33,7 @@
     <div>
       <div id="qrcode_frame"></div>
     </div>
-    <p class="regular-grey-text-small"><%- _.str.sprintf(t('wallet.receive.index.qr_code_explanation'), ledger.config.network.plural) %></p>
+    <p class="regular-grey-text-small"><%- _.str.sprintf(t('wallet.receive.index.qr_code_explanation'), ledger.config.network.plural()) %></p>
   </div>
 </section>
 <div class="dialog-actions-bar">

--- a/app/views/wallet/send/card.eco
+++ b/app/views/wallet/send/card.eco
@@ -1,6 +1,6 @@
 <section id="send_card_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div class="regular-text"><%- t 'wallet.send.card.grab_your_card' %></div>
   <div id="validation_container">

--- a/app/views/wallet/send/index.eco
+++ b/app/views/wallet/send/index.eco
@@ -1,6 +1,6 @@
 <section id="send_index_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <table class="no-table-head">
     <tbody>

--- a/app/views/wallet/send/method.eco
+++ b/app/views/wallet/send/method.eco
@@ -1,6 +1,6 @@
 <section id="send_method_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div class="regular-text"><%- t 'wallet.send.method.select_method' %></div>
   <div id="mobile_table_container"></div>

--- a/app/views/wallet/send/mobile.eco
+++ b/app/views/wallet/send/mobile.eco
@@ -1,6 +1,6 @@
 <section id="send_mobile_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div id="content_container">
     <img src="../assets/images/wallet/pairing_icon.png" width="108" height="60" />

--- a/app/views/wallet/send/preparing.eco
+++ b/app/views/wallet/send/preparing.eco
@@ -1,6 +1,6 @@
 <section id="send_preparing_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div id="content_container">
     <div class="regular-text"><%= t 'wallet.send.preparing.preparing_transaction' %></div>

--- a/app/views/wallet/send/processing.eco
+++ b/app/views/wallet/send/processing.eco
@@ -1,6 +1,6 @@
 <section id="send_processing_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div id="content_container">
     <div class="regular-text"><%= t 'wallet.send.processing.finalizing_transaction' %></div>

--- a/app/views/wallet/send/sign.eco
+++ b/app/views/wallet/send/sign.eco
@@ -1,6 +1,6 @@
 <section id="send_validating_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div id="validating" class="content-container">
     <div class="regular-text"><%= t 'wallet.send.validating.validating_transaction' %></div>

--- a/app/views/wallet/send/validating.eco
+++ b/app/views/wallet/send/validating.eco
@@ -1,6 +1,6 @@
 <section id="send_validating_dialog">
   <header>
-    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural) %></h1>
+    <h1><%= _.str.sprintf(t('wallet.send.common.send_bitcoins'), ledger.config.network.plural()) %></h1>
   </header>
   <div id="content_container">
     <div class="regular-text"><%= t 'wallet.send.validating.validating_transaction' %></div>


### PR DESCRIPTION
With this patch, each language can specify the correct plural form of
each coin (that is, the plural of "bitcoin" is not "bitcoins" in all
possible languages).

Might be a bit too invasive because it changes plural from a variable to a function.