### PR TITLE
Restore support for testnet

### DIFF
--- a/app/src/bitcoin/networks.coffee
+++ b/app/src/bitcoin/networks.coffee
@@ -53,6 +53,7 @@ ledger.bitcoin.Networks =
     version:
       regular: 111
       P2SH: 196
+      XPUB: 0x043587CF
     bitcoinjs: bitcoin.networks.testnet
     ws_chain: 'testnet3'
     dust: 5430

--- a/app/src/preferences/defaults.coffee
+++ b/app/src/preferences/defaults.coffee
@@ -129,6 +129,36 @@ ledger.preferences.bitcoin =
         address: 'https://insight.bitpay.com/tx/%s'
     discoveryGap: 20
 
+ledger.preferences.testnet =
+  Display:
+    units:
+      bitcoin:
+        symbol: 'BTC'
+        unit: 8
+      milibitcoin:
+        symbol: 'mBTC'
+        unit: 5
+      microbitcoin:
+        symbol: 'bits'
+        unit: 2
+
+  # Coin preferences
+  Coin:
+    explorers:
+      blocktrail:
+        name: 'Blocktrail.com'
+        address: 'https://www.blocktrail.com/tBTC/tx/%s'
+      blockr:
+        name: 'Blockr.io'
+        address: 'https://tbtc.blockr.io/tx/info/%s'
+      biteasy:
+        name: 'Biteasy.com'
+        address: 'https://www.biteasy.com/testnet/transactions/%s'
+      insight:
+        name: 'Insight.is'
+        address: 'https://test-insight.bitpay.com/tx/%s'
+    discoveryGap: 20
+
 ledger.preferences.litecoin =
   Display:
     units:


### PR DESCRIPTION
Testnet seems to work again when flashing the testnet app to the Ledger.
Server-side support for the APIs is needed though.