### PR TITLE
add fujicoin

### DIFF
--- a/app/libs/bitcoinjs-min.js
+++ b/app/libs/bitcoinjs-min.js
@@ -14763,6 +14763,20 @@
           feePerKb: 1e4,
           estimateFee: estimateFee("testnet")
         },
+        fujicoin: {
+          magicPrefix: "FujiCoin Signed Message:\n",
+          bip32: {
+            "public": 76067358,
+            "private": 76066276
+          },
+          pubKeyHash: 36,
+          scriptHash: 16,
+          wif: 164,
+          dustThreshold: 0,
+          dustSoftThreshold: 1e5,
+          feePerKb: 1e5,
+          estimateFee: estimateFee("fujicoin")
+        },
         litecoin: {
           magicPrefix: "Litecoin Signed Message:\n",
           bip32: {

--- a/app/src/bitcoin/networks.coffee
+++ b/app/src/bitcoin/networks.coffee
@@ -1,4 +1,12 @@
 
+bitcoin.networks.fujicoin =
+  magicPrefix: '\x19FujiCoin Signed Message:\n',
+  bip32:
+    public: 0x0488b21e,
+    private: 0x0488ade4
+  pubKeyHash: 36
+  scriptHash: 16
+
 bitcoin.networks.dash =
   magicPrefix: '\x19DarkCoin Signed Message:\n',
   bip32:
@@ -150,6 +158,24 @@ ledger.bitcoin.Networks =
       dustThreshold: 546
     dust: 5430
     handleFeePerByte: yes
+
+  fujicoin:
+    name: 'FujiCoin'
+    plural: 'fujicoins'
+    scheme: 'fujicoin:'
+    bolosAppName: 'Fujicoin'
+    ticker: 'FJC'
+    tickerKey:
+      from: 'fromFJC'
+      to: 'toFJC'
+    bip44_coin_type: '75'
+    version:
+      regular: 36
+      P2SH: 16
+      XPUB: 0x0488b21e
+    bitcoinjs: bitcoin.networks.fujicoin
+    dust: 10000
+    handleFeePerByte: no
 
   litecoin:
     name: 'litecoin'

--- a/app/src/preferences/defaults.coffee
+++ b/app/src/preferences/defaults.coffee
@@ -162,6 +162,27 @@ ledger.preferences.testnet =
         address: 'https://test-insight.bitpay.com/tx/%s'
     discoveryGap: 20
 
+ledger.preferences.fujicoin =
+  Display:
+    units:
+      bitcoin:
+        symbol: 'FJC'
+        unit: 8
+      milibitcoin:
+        symbol: 'mFJC'
+        unit: 5
+      microbitcoin:
+        symbol: 'μFJC'
+        unit: 2
+
+  # Coin preferences
+  Coin:
+    explorers:
+      fuji_explorer:
+        name: 'Fujicoin Explorer'
+        address: 'http://explorer.fujicoin.org/tx/%s'
+    discoveryGap: 20
+
 ledger.preferences.litecoin =
   Display:
     units:


### PR DESCRIPTION
Hi LedgerHQ,

Please add Fujicoin.

We are now developing electrum-FJC.
The electrum-FJC for test can be obtained here.
https://bitcointalk.org/index.php?topic=644601.msg20043948#msg20043948

Website: http://www.fujicoin.org/
Explorer: http://explorer.fujicoin.org/

Thanks,
motty

