### PR TITLE
Improved traditional chinese translation

### DIFF
--- a/app/locales/zh-TW/messages.properties
+++ b/app/locales/zh-TW/messages.properties
@@ -1,17 +1,17 @@
 #X-Generator: crowdin.com
 # i18n
-language.name=中國
+language.name=繁體中文
 # Application
 application.name=Ledger Wallet Bitcoin
-application.small_description=Ledger Wallet 能高效、 安全地管理您的比特幣帳戶。
+application.small_description=Ledger Wallet – 高效、安全地管理您的比特幣與萊特幣帳戶。
 application.support_url=http\://support.ledgerwallet.com/
 application.support_key_not_recognized_url=https\://ledger.zendesk.com/hc/en-us/categories/115000813085-TROUBLESHOOTING\n
 application.support_coinkite_url=https\://ledger.zendesk.com/hc/en-us/categories/115000813085-TROUBLESHOOTING\n
-application.commands.reload_page=重新載入當前頁面
+application.commands.reload_page=重新載入目前頁面
 application.commands.reload_application=重新載入應用程式
-application.commands.update_firmware=晶片固件更新
+application.commands.update_firmware=更新硬體韌體
 application.commands.export_logs=匯出全域日誌
-application.singleton.alert_message={APPLICATION_NAME} 應用程式已在運行。請先關閉它，然後重試。
+application.singleton.alert_message={APPLICATION_NAME} 應用程式已在運行。請先關閉它再重試一次。
 
 # Common
 common.default_account_name=我的帳戶
@@ -19,39 +19,39 @@ common.default_recovered_account_name=已恢復的帳戶 %d
 common.date_time_format=L LT [at]
 common.date_format=L
 common.time_format=LT
-common.add=添加
+common.add=新增
 common.close=關閉
 common.cancel=取消
 common.print=列印
-common.copy=副本
+common.copy=複製
 common.finish=%s 配對
 common.confirm=確認
 common.confirmation=確認
 common.send=發送
 common.continue=繼續
-common.erase=抹去
+common.erase=消除
 common.update=更新
 common.restore=還原
-common.later=以後
+common.later=稍後
 common.reset=重置
 common.save=保存
 common.export=出口
 common.help=説明
-common.visit_help_center=訪問説明中心
+common.visit_help_center=造訪説明中心
 common.back=返回
 common.next=下一個
 common.test=測試
 common.show=顯示
-common.yes=對
-common.no=不
+common.yes=是
+common.no=否
 common.name=名稱
 common.email_address=電子郵件地址
 common.send_by_email=通過電子郵件發送
 common.subject=主題
 common.tag=標籤
-common.message=消息
+common.message=訊息
 common.may_take_a_while=請稍等，此操作可能需要幾分鐘。
-common.get_help=請遊覽我們的幫助中心於support.ledgerwallet.com 以查詢更多資訊。 
+common.get_help=請造訪我們的說明中心於 support.ledgerwallet.com 以查詢更多資訊。
 common.signing=登入中...
 common.checking=正在檢查...
 common.sending=正在發送...
@@ -62,32 +62,32 @@ common.keycard.digits=位數
 common.wait=請稍等，這可能需要幾分鐘時間。
 
 # Common errors
-common.errors.unsufficient_balance=你的錢包的價值太低。
-common.errors.wrong_keycode=驗證代碼是不正確的。
+common.errors.unsufficient_balance=錢包中的餘額太低。
+common.errors.wrong_keycode=驗證代碼錯誤。
 common.errors.network_no_response=交易伺服器沒有回應。
 common.errors.network_error=網路錯誤。
 # %s is replaced by the coin name (i.e. bitcoin, litecoin)
-common.errors.invalid_receiver_address=收件者的比特幣位址不正確。
-common.errors.invalid_amount=要發送的金額是不正確。
+common.errors.invalid_receiver_address=收件者的比特幣位址錯誤。
+common.errors.invalid_amount=要發送的金額是錯誤。
 common.errors.invalid_op_return_data=The OP_RETURN data is invalid (must be HEX)
 common.errors.unknown=出現未知的錯誤。
 common.errors.unable_to_validate=無法驗證交易。
-common.errors.secure_screen_cancelled_transaction=智慧手機取消交易。
-common.errors.secure_screen_invalid_pin=智慧手機返回一個錯誤的 pin 碼。
-common.errors.deleting_this_paired_smartphone=通過刪除此智慧手機，你將不再能夠手動驗證交易記錄的此Ledger Wallet。 < br / > 你想要繼續嗎?
+common.errors.secure_screen_cancelled_transaction=智慧型手機取消交易。
+common.errors.secure_screen_invalid_pin=智慧型手機返回一個錯誤的 pin 碼。
+common.errors.deleting_this_paired_smartphone=通過刪除此智慧型手機，你將不再能夠手動驗證交易記錄的此Ledger Wallet。 < br / > 你想要繼續嗎?
 common.errors.going_to_firmware_update=通過切換到固件更新模式，你掛起活動有關的現金將會被打斷.< br / > 你想要繼續嗎?
 common.errors.wrong_transaction_signature=由於硬體故障沒有被正確簽署交易。請聯繫支援立即提供援助。
 common.errors.dust_transaction=交易記錄金額必須至少 %s。
 common.errors.synchronization_error=同步錯誤
 # %s is replaced by the coin name (plural form) (i.e. bitcoins, litecoins)
-common.errors.error_during_synchronization_1=分類帳 API （通往 blockchain） 有一些網路問題和Ledger Wallet 應用程式不能完全同步交易。你的 %s 是安全的破壞我們的 API 只影響應用程式可以顯示。
-common.errors.error_during_synchronization_2=應用程式上顯示的資訊將不是最新，某些事務可能會丟失，和創建新的交易記錄將不工作。它是可能得到你即時平衡和付款使用的替代方法。
+common.errors.error_during_synchronization_1=帳本通訊 API （連接到區塊鏈的 API） 有一些網路問題並且 Ledger Wallet 應用程式無法完全同步所有交易。你的 %s 是安全，而這項錯誤僅會影響應用程式的顯示數據。
+common.errors.error_during_synchronization_2=應用程式上顯示的資訊將不是最新，某些交易可能會遺失而且新增交易記錄將無法運作。可能會需要用替代的方法來取得你在帳戶中的即時的餘額與支付款項。
 common.errors.fill_all_fields=請確保填寫所有的欄位。
-common.errors.not_a_valid_email=電子郵件地址似乎並不有效。
+common.errors.not_a_valid_email=電子郵件似乎並不是有效的郵件地址。
 common.errors.error_occurred=出現錯誤。請稍後再試。
-common.errors.fees_too_high=警告，所選交易記錄費用似乎尤其是高 < br / > 你確認這一數額 (%s) 嗎?
+common.errors.fees_too_high=警告，你所選擇的交易費顯著的高昂。<br />你確認這個費用 (%s) 正確嗎？
 common.errors.cannot_create_account.title=新帳戶
-common.errors.cannot_create_account.subtitle=不允許創建新帳戶，而"%s"為空。請發送到此帳戶的資金或考慮刪除它。
+common.errors.cannot_create_account.subtitle=不允許創建新帳戶，而 "%s" 為空。請發送到此帳戶的資金或考慮刪除它。
 
 # Common QrCode
 common.qrcode.scan_qrcode=掃描二維碼
@@ -101,10 +101,10 @@ common.fees.slow=低 (慢確認)
 
 # Common help
 common.help.help=説明
-common.help.browse_knowledge_base=流覽知識庫
+common.help.browse_knowledge_base=瀏覽知識庫
 common.help.contact_support_team=聯繫支援小組
-common.help.self_help=為立即自助
-common.help.dedicated_help=快速的援助
+common.help.self_help=自助服務
+common.help.dedicated_help=即時的協助
 common.help.attach_debug_logs=附加調試日誌
 common.help.support_tag=支援
 common.help.feature_request_tag=功能請求
@@ -112,7 +112,7 @@ common.help.sales_tag=銷售
 common.help.other_tag=其他
 common.help.sent_message=發送消息
 common.help.not_sent_message=消息未發送
-common.help.thank_you_message=謝謝你與支援小組聯繫。不久我們會跟你聯絡。
+common.help.thank_you_message=謝謝你與支援小組聯繫。不久後我們會跟你聯絡。
 
 # Common flash
 common.flash.link=更多的資訊......
@@ -131,7 +131,7 @@ onboading.common.help=需要幫助嗎？與Ledger 援小組聯繫。
 onboarding.device.plug.welcome_instruction=若要開始，插頭和解鎖你的Ledger Wallet 。
 onboarding.device.plug.welcome_bolos_instruction=如果您的設備支援多種貨幣，打開所需的應用程式。
 onboarding.device.plug.is_not_recognized=如果不承認你的Ledger Wallet，請訪問我們的説明中心。
-onboarding.device.plug.whats_new=最新動態? 
+onboarding.device.plug.whats_new=最新動態?
 
 # Onboarding Device Unplug
 onboarding.device.unplug.unlock_my_wallet=解鎖我的錢包
@@ -151,7 +151,7 @@ onboarding.device.opening.not_opening=如果你的Ledger Wallet打不開，請�
 
 # Onboarding Device Update
 onboarding.device.update.new_firmware_available=一個新的固件更新供您Ledger Wallet (%s)。
-onboarding.device.update.new_1_0_0=此更新將添加新的身份驗證方法來驗證你的智慧手機傳出交易。
+onboarding.device.update.new_1_0_0=此更新將添加新的身份驗證方法來驗證你的智慧型手機傳出交易。
 onboarding.device.update.new_1_0_1=此更新將添加 P2SH 支援和修復關鍵 (但不是比特幣威脅) 病毒在加密庫中。
 
 # Onboarding Device Unsupported
@@ -175,7 +175,7 @@ onboarding.device.errors.wrongpin.unplug_plug=拔下，然後插回你的Ledger 
 
 # Onboarding Device Errors Forged
 onboarding.device.errors.forged.forbidden_access=出於安全原因，您無權使用此應用程式。
-onboarding.device.errors.forged.get_help=請遊覽我們的幫助中心於support.ledgerwallet.com 以查詢更多資訊。 
+onboarding.device.errors.forged.get_help=請遊覽我們的幫助中心於support.ledgerwallet.com 以查詢更多資訊。
 
 
 # Onboarding Management
@@ -272,14 +272,14 @@ update.index.important_notice=重要通知
 # %s is replaced by the coin name (plural form) (i.e. bitcoins, litecoins)
 update.index.update_process=更新過程需要抹去你的Ledger Wallet。 < br / > 你恢復工作表將允許您恢復您的比特幣。
 update.index.clicking_continue=按一下繼續，您確認要持有 <b>安全卡 QR 代碼</b> 和您的 <b>24 字恢復短語</b>。如果您嘗試更新你的Ledger Wallet如果沒有此資訊，您將失去您的比特幣。
-update.index.please_note=請注意\: 您將需要對你的智慧手機再到重新啟用移動第二個因素身份驗證。
+update.index.please_note=請注意\: 您將需要對你的智慧型手機再到重新啟用移動第二個因素身份驗證。
 
 # Update Plug
 update.plug.plug_your_wallet=插上你的Ledger Wallet
 update.plug.insert_your_wallet=在 USB 插入你的Ledger Wallet。
 
 # Update Unplug
-update.unplug.unplug_your_wallet=拔出你的Ledger Wallet 
+update.unplug.unplug_your_wallet=拔出你的Ledger Wallet
 update.unplug.remove_your_wallet=從 USB 刪除Ledger Wallet 。
 
 # Update Seed
@@ -292,7 +292,7 @@ update.erasing.erasure_confirmation=重置確認
 update.erasing.ready_to_start_process=你將會擦除你Ledger Wallet 。
 # %s is replaced by the coin name (plural form) (i.e. bitcoins, litecoins)
 update.erasing.clicking_continue=按一下繼續，您確認要佔有你的 <b>24 字恢復短語</b>。 <br/>如果您嘗試更新你的Ledger Wallet 沒有它，你將失去你的 %s。
-update.erasing.please_note=請注意\: 您將需要對你的智慧手機再到重新啟用移動第二個因素身份驗證。
+update.erasing.please_note=請注意\: 您將需要對你的智慧型手機再到重新啟用移動第二個因素身份驗證。
 
 # Update Updating
 update.updating.update_confirmation=更新確認
@@ -467,8 +467,8 @@ wallet.send.card.to=自
 
 # Wallet Send Method
 wallet.send.method.select_method=請選擇一種驗證方法進行身份驗證從Ledger Wallet傳出交易\:
-wallet.send.method.pair_a_mobile_phone=配對智慧手機
-wallet.send.method.mobile_phone=智慧手機
+wallet.send.method.pair_a_mobile_phone=配對智慧型手機
+wallet.send.method.mobile_phone=智慧型手機
 wallet.send.method.security_card=安全卡
 wallet.send.method.single_paired_device=%s 配對
 wallet.send.method.multiple_paired_devices=%s 配對
@@ -491,15 +491,15 @@ wallet.send.errors.transaction_completed=成功地完成交易。
 wallet.send.errors.cancelled=取消付款
 
 # Wallet Pairing Common
-wallet.pairing.common.pair_a_new_mobile=配對智慧手機
+wallet.pairing.common.pair_a_new_mobile=配對智慧型手機
 
 # Wallet Pairing Errors
 wallet.pairing.errors.pairing_failed=配對失敗
 wallet.pairing.errors.pairing_succeeded=配對成功
-wallet.pairing.errors.dongle_is_now_paired=你的Ledger Wallet現在搭配你的智慧手機"%s"。
+wallet.pairing.errors.dongle_is_now_paired=你的Ledger Wallet現在搭配你的智慧型手機"%s"。
 wallet.pairing.errors.inconsistent_state=錯誤的事 (不一致的狀態)。
 wallet.pairing.errors.client_cancelled=移動應用程式取消了配對的過程。
-wallet.pairing.errors.dongle_needs_power_cycle=Ledger Wallet需要拔出並插入回在對新的智慧手機。
+wallet.pairing.errors.dongle_needs_power_cycle=Ledger Wallet需要拔出並插入回在對新的智慧型手機。
 wallet.pairing.errors.invalid_challenge_response=安全卡驗證代碼是不正確的。
 wallet.pairing.errors.dongle_cancelled=你的Ledger Wallet取消了配對的過程。
 wallet.pairing.errors.unknown=出現未知的錯誤。
@@ -513,10 +513,10 @@ wallet.pairing.index.scan_this_qrcode=掃描此配對的二維碼。
 
 # Wallet Pairing Progress
 wallet.pairing.progress.pairing_with_mobile_device=配對的進展......
-wallet.pairing.progress.follow_instructions=按照智慧手機螢幕上顯示的說明。
+wallet.pairing.progress.follow_instructions=按照智慧型手機螢幕上顯示的說明。
 
 # Wallet Pairing Finalizing
-wallet.pairing.finalizing.assign_a_name=完成，請把名字給這個智慧手機。
+wallet.pairing.finalizing.assign_a_name=完成，請把名字給這個智慧型手機。
 wallet.pairing.finalizing.placeholder_name=智慧手機名稱
 wallet.pairing.finalizing.default_name=我的智慧手機
 wallet.pairing.finalizing.name_already_used_by_paired_device=此名稱已由另一個智慧手機使用。


### PR DESCRIPTION
When I use ledger wallet chrome app I found some translation issues, most of the issues is inaccurate/incorrect translation and there is one major issue: `Language` is totally wrong.

in original translation `language.name` is `中國` (China) which is wrong since China is a country not a language. the correct one is `traditional chinese` (繁體中文).

there are two different kind of chinese: `Simplified Chinese` and `Traditional Chinese`. Simplified Chinese is mainly used in China and Malaysia, and Traditional Chinese is mainly used is Taiwan.

So that is the reason I send this pull request, hope you guys can accept my pr 😺 