### PR TITLE
Corrected PIVX BIP44 coin type according to slip44

### DIFF
--- a/app/src/bitcoin/networks.coffee
+++ b/app/src/bitcoin/networks.coffee
@@ -757,7 +757,7 @@ ledger.bitcoin.Networks =
     tickerKey:
       from: 'fromPIVX'
       to: 'toPIVX'
-    bip44_coin_type: '77'
+    bip44_coin_type: '119'
     handleSegwit: no
     isSegwitSupported: no
     version:


### PR DESCRIPTION
Refer to issue #77.

Also refer to issue raised at [https://github.com/iancoleman/bip39/pull/135](https://github.com/iancoleman/bip39/pull/135).