### PR TITLE
Add Ravencoin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ You can build the chrome application for other coins. Run `gulp clean build pack
  - dogecoin
  - dogecoin_test
  - zencash
+ - ravencoin
 
 Note: that the API is only available for bitcoin and testnet right now.
-

--- a/app/src/bitcoin/networks.coffee
+++ b/app/src/bitcoin/networks.coffee
@@ -126,6 +126,14 @@ bitcoin.networks.digibyte =
   pubKeyHash: 30
   scriptHash: 5
 
+bitcoin.networks.ravencoin =
+  magicPrefix: '\x16Raven Signed Message:\n'
+  bip32:
+    public: 0x0488B21E,
+    private: 0x0488ADE4
+  pubKeyHash: 60
+  scriptHash: 122
+
 ledger.bitcoin ||= {}
 ledger.bitcoin.Networks =
   bitcoin:
@@ -901,6 +909,27 @@ ledger.bitcoin.Networks =
       P2SH: 5
       XPUB: 0x0488b21E
     bitcoinjs: bitcoin.networks.digibyte
+    dust: 10000
+    handleFeePerByte: no
+    areTransactionTimestamped: no
+
+  ravencoin:
+    name: 'ravencoin'
+    display_name: 'ravencoin'
+    plural: 'ravencoins'
+    scheme: 'ravencoin:'
+    bolosAppName: 'ravencoin'
+    ticker: 'rvn'
+    tickerKey:
+      from: 'fromRVN'
+      to: 'toRVN'
+    bip44_coin_type: '175'
+    isSegwitSupported: no
+    version:
+      regular: 60
+      P2SH: 122
+      XPUB: 0x0488B21E
+    bitcoinjs: bitcoin.networks.ravencoin
     dust: 10000
     handleFeePerByte: no
     areTransactionTimestamped: no

--- a/app/src/preferences/defaults.coffee
+++ b/app/src/preferences/defaults.coffee
@@ -732,4 +732,28 @@ ledger.preferences.digibyte =
         address: 'https://digiexplorer.info/tx/%s'
     discoveryGap: 20
 
+ledger.preferences.ravencoin =
+  Display:
+    units:
+      bitcoin:
+        symbol: 'RVN'
+        unit: 8
+      milibitcoin:
+        symbol: 'mRVN'
+        unit: 5
+
+  # Coin preferences
+  Coin:
+    explorers:
+      hash4life:
+        name: 'Hash4Life'
+        address: 'https://rvn.hash4.life/tx/%s'
+      rvnblockchain:
+        name: 'raven-blockchain.info'
+        address: 'http://raven-blockchain.info/tx/%s'
+      rvnhodl:
+        name: 'rvnhodl'
+        address: 'http://rvnhodl.com/tx/%s'
+    discoveryGap: 20
+
 ledger.preferences.common.setCoin("bitcoin")


### PR DESCRIPTION
Adding Ravencoin support to the Ledger chrome wallet app.

Pull request for Ravencoin support on blue-app-btc has been submitted [here](https://github.com/LedgerHQ/blue-app-btc/pull/39).