### PR TITLE
Updated Stratis Extended Pub Key prefix

### DIFF
--- a/app/src/bitcoin/networks.coffee
+++ b/app/src/bitcoin/networks.coffee
@@ -49,8 +49,8 @@ bitcoin.networks.qtum =
 bitcoin.networks.stratis =
   magicPrefix: '\x18Stratis Signed Message:\n'
   bip32:
-    public: 0x0488c21e,
-    private: 0x05358394
+    public: 0x0488B21E,
+    private: 0x0488ADE4
   pubKeyHash: 63
   scriptHash: 125
 
@@ -636,7 +636,7 @@ ledger.bitcoin.Networks =
     version:
       regular: 63
       P2SH: 125
-      XPUB: 0x0488c21e
+      XPUB: 0x0488B21E
     bitcoinjs: bitcoin.networks.stratis
     dust: 10000
     handleFeePerByte: no


### PR DESCRIPTION
The goal of this PR is to update the values of Stratis' Extended Public and Private Key prefixes in Ledger applications, in order for them to be in line with the ones from Stratis' code.

At the moment, Ledger applications have the following values for Stratis' Extended Public and Private Key prefixes:
0x0488C21E/76071454 for ExtPubKey
0x0488B2DD/87393172 for ExtPrivKey.

Stratis' BIP44 compatible wallet uses different values for these prefixes.
The values in use are the same as Bitcoin:
0x0488B21E/76067358 for ExtPubKey
0x0488ADE4/76066276 for ExtPrivKey

See here: https://github.com/stratisproject/StratisBitcoinFullNode/blob/master/src/NBitcoin/Networks.cs#L425
